### PR TITLE
Update API path for deleting SSH keys

### DIFF
--- a/lib/fog/digitalocean/requests/compute_v2/delete_ssh_key.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/delete_ssh_key.rb
@@ -10,7 +10,7 @@ module Fog
               'Content-Type' => "application/json; charset=UTF-8",
             },
             :method  => 'DELETE',
-            :path    => "/v2/account/keys#{id}",
+            :path    => "/v2/account/keys/#{id}",
           )
         end
       end


### PR DESCRIPTION
The current path is incorrect (missing a '/'), resulting in a 404 whenever you try to destroy an SSH key on DigitalOcean V2.
